### PR TITLE
hotfix: search function orcid error

### DIFF
--- a/src/search.py
+++ b/src/search.py
@@ -101,7 +101,7 @@ def sort_experts(authors, topic, notable_institutions=None, num_recent_years=2):
         # Author data
         country_code = author["author_country_code"]
         author_h_index = works_count = None
-        cited_by_count = institution = None
+        cited_by_count = institution = orcid = None
 
         if author_data['summary_stats']['h_index']:
             author_h_index = author_data['summary_stats']['h_index']

--- a/tkinter_ui.py
+++ b/tkinter_ui.py
@@ -23,7 +23,7 @@ def search_experts_callback(topic):
         global EXPERTS
 
         # Search database for the topic
-        EXPERTS = mongodb.get_topic_experts_using_db(COLLECTION, topic)
+        EXPERTS = mongodb.get_topic_experts_using_db(COLLECTION, topic, "")
 
         # If topic doesn't exists in database, use API
         if not EXPERTS:


### PR DESCRIPTION
## What

* Fix error caused by; `orcid` variable not initialized as `None`.
* This leads search request to fail if author doesn't have `orcid`.